### PR TITLE
Get ActionNetwork events from all subgroups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ SLACK_TOPIC_ARN=
 
 # Action Network config
 # Key can be set for development to skip secrets manager
-ACTION_NETWORK_KEY=
+ACTION_NETWORK_GROUP_KEY_MAP=
 ACTION_NETWORK_SECRET_ID=actionnetwork
 
 # Airtable

--- a/src/actionnetwork.py
+++ b/src/actionnetwork.py
@@ -41,8 +41,3 @@ class ActionNetwork(pyactionnetwork.ActionNetworkApi):
             for raw_event in self.raw_events(**kwargs)
             if raw_event['origin_system'] != 'Facebook Sync'
         ]
-
-    def event(self, event_id):
-        url = self.resource_to_url('events')
-        url += '/' + event_id
-        return ActionNetworkEvent(requests.get(url, headers=self.headers).json())

--- a/src/events.py
+++ b/src/events.py
@@ -212,6 +212,14 @@ class AirtableEvent(Event):
         self.set(description, 'fields', 'Description')
 
     @property
+    def host_group(self):
+        return self.lookup('fields', 'Host Group')
+    
+    @host_group.setter
+    def host_group(self, group_name):
+        return self.set(group_name, 'fields', 'Host Group')
+
+    @property
     def start(self):
         return AirtableEvent.to_datetime(self.lookup('fields', 'Start Time'))
 
@@ -270,6 +278,10 @@ class ActionNetworkEvent(Event):
     @property
     def description(self):
         return self.lookup('description')
+    
+    @property
+    def host_group(self):
+        return self.lookup('action_network:sponsor', 'title')
 
     @property
     def start(self):


### PR DESCRIPTION
This adds functionality to pull ActionNetwork events from subgroups.

Pulling singular events from subgroups was not reliable (I was able to successfully access a single event once, but also encountered many 404 errors), so I removed the code to pull single events.

The corresponding restructuring has already been made in Secrets Manager:  there is a secret called `actionnetwork/production` and the secret value is a map from subgroup name to api key. There is also a secret named `actionnetwork/development` with the same structure which only contains keys for test groups.