### PR TITLE
Bugfixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,9 @@
 
 # AWS credentials
 AWS_ACCESS_KEY_ID=
-AWS_DEFAULT_REGION=
 AWS_SECRET_ACCESS_KEY=
+AWS_DEFAULT_REGION=
+AWS_ROLE_ARN=
 
 # --- Required for Runtime
 

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ name = "pypi"
 boto3 = "*"
 pyactionnetwork = "*"
 pyairtable = "*"
-pytz = "*"
 requests = "*"
 
 [dev-packages]
@@ -16,7 +15,7 @@ ipython = "*"
 pytest = "*"
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"
 
 [packages.fest]
 git = "https://github.com/BostonDSA/fest.git"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8f24e5d8069c4c898978854e30faeb73956a9b793b1222aad6159e8ad37b54e5"
+            "sha256": "66dd815ec64e90b3383107c761f694db9b81df8461e81c62503c99205fb54d57"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.11"
         },
         "sources": [
             {
@@ -26,20 +26,20 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:a5cf93b202568e9d378afdc84be55a6dedf11d30156289fe829e23e6d7dccabb",
-                "sha256:a99150a30c038c73e89662836820a8cce914afab5ea377942a37c484b85f4438"
+                "sha256:2dd93e5c530334fbc74a662f269fa8bfc4c3b7321f9dbe2d53f7c8e57fe5f6dd",
+                "sha256:beefa8e8e1cf5f904dd95736f3516508f6a0cf396ff46aa166a136107cc2ff51"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==1.28.64"
+            "version": "==1.28.69"
         },
         "botocore": {
             "hashes": [
-                "sha256:7b709310343a5b430ec9025b2e17c0bac6b16c05f1ac1d9521dece3f10c71bac",
-                "sha256:d8eb4b724ac437343359b318d73de0cfae0fecb24095827e56135b0ad6b44caf"
+                "sha256:26b1d2f82cc24987d1c7cc783b2fee04908a8f7b293bf1663884eb0768b1eedf",
+                "sha256:412439a199ada10c6284df1f48395928676d81d51339b1a93217cfd4c4f1c9a6"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.64"
+            "version": "==1.31.69"
         },
         "cachetools": {
             "hashes": [
@@ -59,99 +59,99 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:02673e456dc5ab13659f85196c534dc596d4ef260e4d86e856c3b2773ce09843",
-                "sha256:02af06682e3590ab952599fbadac535ede5d60d78848e555aa58d0c0abbde786",
-                "sha256:03680bb39035fbcffe828eae9c3f8afc0428c91d38e7d61aa992ef7a59fb120e",
-                "sha256:0570d21da019941634a531444364f2482e8db0b3425fcd5ac0c36565a64142c8",
-                "sha256:09c77f964f351a7369cc343911e0df63e762e42bac24cd7d18525961c81754f4",
-                "sha256:0d3d5b7db9ed8a2b11a774db2bbea7ba1884430a205dbd54a32d61d7c2a190fa",
-                "sha256:1063da2c85b95f2d1a430f1c33b55c9c17ffaf5e612e10aeaad641c55a9e2b9d",
-                "sha256:12ebea541c44fdc88ccb794a13fe861cc5e35d64ed689513a5c03d05b53b7c82",
-                "sha256:153e7b6e724761741e0974fc4dcd406d35ba70b92bfe3fedcb497226c93b9da7",
-                "sha256:15b26ddf78d57f1d143bdf32e820fd8935d36abe8a25eb9ec0b5a71c82eb3895",
-                "sha256:1872d01ac8c618a8da634e232f24793883d6e456a66593135aeafe3784b0848d",
-                "sha256:187d18082694a29005ba2944c882344b6748d5be69e3a89bf3cc9d878e548d5a",
-                "sha256:1b2919306936ac6efb3aed1fbf81039f7087ddadb3160882a57ee2ff74fd2382",
-                "sha256:232ac332403e37e4a03d209a3f92ed9071f7d3dbda70e2a5e9cff1c4ba9f0678",
-                "sha256:23e8565ab7ff33218530bc817922fae827420f143479b753104ab801145b1d5b",
-                "sha256:24817cb02cbef7cd499f7c9a2735286b4782bd47a5b3516a0e84c50eab44b98e",
-                "sha256:249c6470a2b60935bafd1d1d13cd613f8cd8388d53461c67397ee6a0f5dce741",
-                "sha256:24a91a981f185721542a0b7c92e9054b7ab4fea0508a795846bc5b0abf8118d4",
-                "sha256:2502dd2a736c879c0f0d3e2161e74d9907231e25d35794584b1ca5284e43f596",
-                "sha256:250c9eb0f4600361dd80d46112213dff2286231d92d3e52af1e5a6083d10cad9",
-                "sha256:278c296c6f96fa686d74eb449ea1697f3c03dc28b75f873b65b5201806346a69",
-                "sha256:2935ffc78db9645cb2086c2f8f4cfd23d9b73cc0dc80334bc30aac6f03f68f8c",
-                "sha256:2f4a0033ce9a76e391542c182f0d48d084855b5fcba5010f707c8e8c34663d77",
-                "sha256:30a85aed0b864ac88309b7d94be09f6046c834ef60762a8833b660139cfbad13",
-                "sha256:380c4bde80bce25c6e4f77b19386f5ec9db230df9f2f2ac1e5ad7af2caa70459",
-                "sha256:3ae38d325b512f63f8da31f826e6cb6c367336f95e418137286ba362925c877e",
-                "sha256:3b447982ad46348c02cb90d230b75ac34e9886273df3a93eec0539308a6296d7",
-                "sha256:3debd1150027933210c2fc321527c2299118aa929c2f5a0a80ab6953e3bd1908",
-                "sha256:4162918ef3098851fcd8a628bf9b6a98d10c380725df9e04caf5ca6dd48c847a",
-                "sha256:468d2a840567b13a590e67dd276c570f8de00ed767ecc611994c301d0f8c014f",
-                "sha256:4cc152c5dd831641e995764f9f0b6589519f6f5123258ccaca8c6d34572fefa8",
-                "sha256:542da1178c1c6af8873e143910e2269add130a299c9106eef2594e15dae5e482",
-                "sha256:557b21a44ceac6c6b9773bc65aa1b4cc3e248a5ad2f5b914b91579a32e22204d",
-                "sha256:5707a746c6083a3a74b46b3a631d78d129edab06195a92a8ece755aac25a3f3d",
-                "sha256:588245972aca710b5b68802c8cad9edaa98589b1b42ad2b53accd6910dad3545",
-                "sha256:5adf257bd58c1b8632046bbe43ee38c04e1038e9d37de9c57a94d6bd6ce5da34",
-                "sha256:619d1c96099be5823db34fe89e2582b336b5b074a7f47f819d6b3a57ff7bdb86",
-                "sha256:63563193aec44bce707e0c5ca64ff69fa72ed7cf34ce6e11d5127555756fd2f6",
-                "sha256:67b8cc9574bb518ec76dc8e705d4c39ae78bb96237cb533edac149352c1f39fe",
-                "sha256:6a685067d05e46641d5d1623d7c7fdf15a357546cbb2f71b0ebde91b175ffc3e",
-                "sha256:70f1d09c0d7748b73290b29219e854b3207aea922f839437870d8cc2168e31cc",
-                "sha256:750b446b2ffce1739e8578576092179160f6d26bd5e23eb1789c4d64d5af7dc7",
-                "sha256:7966951325782121e67c81299a031f4c115615e68046f79b85856b86ebffc4cd",
-                "sha256:7b8b8bf1189b3ba9b8de5c8db4d541b406611a71a955bbbd7385bbc45fcb786c",
-                "sha256:7f5d10bae5d78e4551b7be7a9b29643a95aded9d0f602aa2ba584f0388e7a557",
-                "sha256:805dfea4ca10411a5296bcc75638017215a93ffb584c9e344731eef0dcfb026a",
-                "sha256:81bf654678e575403736b85ba3a7867e31c2c30a69bc57fe88e3ace52fb17b89",
-                "sha256:82eb849f085624f6a607538ee7b83a6d8126df6d2f7d3b319cb837b289123078",
-                "sha256:85a32721ddde63c9df9ebb0d2045b9691d9750cb139c161c80e500d210f5e26e",
-                "sha256:86d1f65ac145e2c9ed71d8ffb1905e9bba3a91ae29ba55b4c46ae6fc31d7c0d4",
-                "sha256:86f63face3a527284f7bb8a9d4f78988e3c06823f7bea2bd6f0e0e9298ca0403",
-                "sha256:8eaf82f0eccd1505cf39a45a6bd0a8cf1c70dcfc30dba338207a969d91b965c0",
-                "sha256:93aa7eef6ee71c629b51ef873991d6911b906d7312c6e8e99790c0f33c576f89",
-                "sha256:96c2b49eb6a72c0e4991d62406e365d87067ca14c1a729a870d22354e6f68115",
-                "sha256:9cf3126b85822c4e53aa28c7ec9869b924d6fcfb76e77a45c44b83d91afd74f9",
-                "sha256:9fe359b2e3a7729010060fbca442ca225280c16e923b37db0e955ac2a2b72a05",
-                "sha256:a0ac5e7015a5920cfce654c06618ec40c33e12801711da6b4258af59a8eff00a",
-                "sha256:a3f93dab657839dfa61025056606600a11d0b696d79386f974e459a3fbc568ec",
-                "sha256:a4b71f4d1765639372a3b32d2638197f5cd5221b19531f9245fcc9ee62d38f56",
-                "sha256:aae32c93e0f64469f74ccc730a7cb21c7610af3a775157e50bbd38f816536b38",
-                "sha256:aaf7b34c5bc56b38c931a54f7952f1ff0ae77a2e82496583b247f7c969eb1479",
-                "sha256:abecce40dfebbfa6abf8e324e1860092eeca6f7375c8c4e655a8afb61af58f2c",
-                "sha256:abf0d9f45ea5fb95051c8bfe43cb40cda383772f7e5023a83cc481ca2604d74e",
-                "sha256:ac71b2977fb90c35d41c9453116e283fac47bb9096ad917b8819ca8b943abecd",
-                "sha256:ada214c6fa40f8d800e575de6b91a40d0548139e5dc457d2ebb61470abf50186",
-                "sha256:b09719a17a2301178fac4470d54b1680b18a5048b481cb8890e1ef820cb80455",
-                "sha256:b1121de0e9d6e6ca08289583d7491e7fcb18a439305b34a30b20d8215922d43c",
-                "sha256:b3b2316b25644b23b54a6f6401074cebcecd1244c0b8e80111c9a3f1c8e83d65",
-                "sha256:b3d9b48ee6e3967b7901c052b670c7dda6deb812c309439adaffdec55c6d7b78",
-                "sha256:b5bcf60a228acae568e9911f410f9d9e0d43197d030ae5799e20dca8df588287",
-                "sha256:b8f3307af845803fb0b060ab76cf6dd3a13adc15b6b451f54281d25911eb92df",
-                "sha256:c2af80fb58f0f24b3f3adcb9148e6203fa67dd3f61c4af146ecad033024dde43",
-                "sha256:c350354efb159b8767a6244c166f66e67506e06c8924ed74669b2c70bc8735b1",
-                "sha256:c5a74c359b2d47d26cdbbc7845e9662d6b08a1e915eb015d044729e92e7050b7",
-                "sha256:c71f16da1ed8949774ef79f4a0260d28b83b3a50c6576f8f4f0288d109777989",
-                "sha256:d47ecf253780c90ee181d4d871cd655a789da937454045b17b5798da9393901a",
-                "sha256:d7eff0f27edc5afa9e405f7165f85a6d782d308f3b6b9d96016c010597958e63",
-                "sha256:d97d85fa63f315a8bdaba2af9a6a686e0eceab77b3089af45133252618e70884",
-                "sha256:db756e48f9c5c607b5e33dd36b1d5872d0422e960145b08ab0ec7fd420e9d649",
-                "sha256:dc45229747b67ffc441b3de2f3ae5e62877a282ea828a5bdb67883c4ee4a8810",
-                "sha256:e0fc42822278451bc13a2e8626cf2218ba570f27856b536e00cfa53099724828",
-                "sha256:e39c7eb31e3f5b1f88caff88bcff1b7f8334975b46f6ac6e9fc725d829bc35d4",
-                "sha256:e46cd37076971c1040fc8c41273a8b3e2c624ce4f2be3f5dfcb7a430c1d3acc2",
-                "sha256:e5c1502d4ace69a179305abb3f0bb6141cbe4714bc9b31d427329a95acfc8bdd",
-                "sha256:edfe077ab09442d4ef3c52cb1f9dab89bff02f4524afc0acf2d46be17dc479f5",
-                "sha256:effe5406c9bd748a871dbcaf3ac69167c38d72db8c9baf3ff954c344f31c4cbe",
-                "sha256:f0d1e3732768fecb052d90d62b220af62ead5748ac51ef61e7b32c266cac9293",
-                "sha256:f5969baeaea61c97efa706b9b107dcba02784b1601c74ac84f2a532ea079403e",
-                "sha256:f8888e31e3a85943743f8fc15e71536bda1c81d5aa36d014a3c0c44481d7db6e",
-                "sha256:fc52b79d83a3fe3a360902d3f5d79073a993597d48114c29485e9431092905d8"
+                "sha256:06cf46bdff72f58645434d467bf5228080801298fbba19fe268a01b4534467f5",
+                "sha256:0c8c61fb505c7dad1d251c284e712d4e0372cef3b067f7ddf82a7fa82e1e9a93",
+                "sha256:10b8dd31e10f32410751b3430996f9807fc4d1587ca69772e2aa940a82ab571a",
+                "sha256:1171ef1fc5ab4693c5d151ae0fdad7f7349920eabbaca6271f95969fa0756c2d",
+                "sha256:17a866d61259c7de1bdadef418a37755050ddb4b922df8b356503234fff7932c",
+                "sha256:1d6bfc32a68bc0933819cfdfe45f9abc3cae3877e1d90aac7259d57e6e0f85b1",
+                "sha256:1ec937546cad86d0dce5396748bf392bb7b62a9eeb8c66efac60e947697f0e58",
+                "sha256:223b4d54561c01048f657fa6ce41461d5ad8ff128b9678cfe8b2ecd951e3f8a2",
+                "sha256:2465aa50c9299d615d757c1c888bc6fef384b7c4aec81c05a0172b4400f98557",
+                "sha256:28f512b9a33235545fbbdac6a330a510b63be278a50071a336afc1b78781b147",
+                "sha256:2c092be3885a1b7899cd85ce24acedc1034199d6fca1483fa2c3a35c86e43041",
+                "sha256:2c4c99f98fc3a1835af8179dcc9013f93594d0670e2fa80c83aa36346ee763d2",
+                "sha256:31445f38053476a0c4e6d12b047b08ced81e2c7c712e5a1ad97bc913256f91b2",
+                "sha256:31bbaba7218904d2eabecf4feec0d07469284e952a27400f23b6628439439fa7",
+                "sha256:34d95638ff3613849f473afc33f65c401a89f3b9528d0d213c7037c398a51296",
+                "sha256:352a88c3df0d1fa886562384b86f9a9e27563d4704ee0e9d56ec6fcd270ea690",
+                "sha256:39b70a6f88eebe239fa775190796d55a33cfb6d36b9ffdd37843f7c4c1b5dc67",
+                "sha256:3c66df3f41abee950d6638adc7eac4730a306b022570f71dd0bd6ba53503ab57",
+                "sha256:3f70fd716855cd3b855316b226a1ac8bdb3caf4f7ea96edcccc6f484217c9597",
+                "sha256:3f9bc2ce123637a60ebe819f9fccc614da1bcc05798bbbaf2dd4ec91f3e08846",
+                "sha256:3fb765362688821404ad6cf86772fc54993ec11577cd5a92ac44b4c2ba52155b",
+                "sha256:45f053a0ece92c734d874861ffe6e3cc92150e32136dd59ab1fb070575189c97",
+                "sha256:46fb9970aa5eeca547d7aa0de5d4b124a288b42eaefac677bde805013c95725c",
+                "sha256:4cb50a0335382aac15c31b61d8531bc9bb657cfd848b1d7158009472189f3d62",
+                "sha256:4e12f8ee80aa35e746230a2af83e81bd6b52daa92a8afaef4fea4a2ce9b9f4fa",
+                "sha256:4f3100d86dcd03c03f7e9c3fdb23d92e32abbca07e7c13ebd7ddfbcb06f5991f",
+                "sha256:4f6e2a839f83a6a76854d12dbebde50e4b1afa63e27761549d006fa53e9aa80e",
+                "sha256:4f861d94c2a450b974b86093c6c027888627b8082f1299dfd5a4bae8e2292821",
+                "sha256:501adc5eb6cd5f40a6f77fbd90e5ab915c8fd6e8c614af2db5561e16c600d6f3",
+                "sha256:520b7a142d2524f999447b3a0cf95115df81c4f33003c51a6ab637cbda9d0bf4",
+                "sha256:548eefad783ed787b38cb6f9a574bd8664468cc76d1538215d510a3cd41406cb",
+                "sha256:555fe186da0068d3354cdf4bbcbc609b0ecae4d04c921cc13e209eece7720727",
+                "sha256:55602981b2dbf8184c098bc10287e8c245e351cd4fdcad050bd7199d5a8bf514",
+                "sha256:58e875eb7016fd014c0eea46c6fa92b87b62c0cb31b9feae25cbbe62c919f54d",
+                "sha256:5a3580a4fdc4ac05f9e53c57f965e3594b2f99796231380adb2baaab96e22761",
+                "sha256:5b70bab78accbc672f50e878a5b73ca692f45f5b5e25c8066d748c09405e6a55",
+                "sha256:5ceca5876032362ae73b83347be8b5dbd2d1faf3358deb38c9c88776779b2e2f",
+                "sha256:61f1e3fb621f5420523abb71f5771a204b33c21d31e7d9d86881b2cffe92c47c",
+                "sha256:633968254f8d421e70f91c6ebe71ed0ab140220469cf87a9857e21c16687c034",
+                "sha256:63a6f59e2d01310f754c270e4a257426fe5a591dc487f1983b3bbe793cf6bac6",
+                "sha256:63accd11149c0f9a99e3bc095bbdb5a464862d77a7e309ad5938fbc8721235ae",
+                "sha256:6db3cfb9b4fcecb4390db154e75b49578c87a3b9979b40cdf90d7e4b945656e1",
+                "sha256:71ef3b9be10070360f289aea4838c784f8b851be3ba58cf796262b57775c2f14",
+                "sha256:7ae8e5142dcc7a49168f4055255dbcced01dc1714a90a21f87448dc8d90617d1",
+                "sha256:7b6cefa579e1237ce198619b76eaa148b71894fb0d6bcf9024460f9bf30fd228",
+                "sha256:800561453acdecedaac137bf09cd719c7a440b6800ec182f077bb8e7025fb708",
+                "sha256:82ca51ff0fc5b641a2d4e1cc8c5ff108699b7a56d7f3ad6f6da9dbb6f0145b48",
+                "sha256:851cf693fb3aaef71031237cd68699dded198657ec1e76a76eb8be58c03a5d1f",
+                "sha256:854cc74367180beb327ab9d00f964f6d91da06450b0855cbbb09187bcdb02de5",
+                "sha256:87071618d3d8ec8b186d53cb6e66955ef2a0e4fa63ccd3709c0c90ac5a43520f",
+                "sha256:871d045d6ccc181fd863a3cd66ee8e395523ebfbc57f85f91f035f50cee8e3d4",
+                "sha256:8aee051c89e13565c6bd366813c386939f8e928af93c29fda4af86d25b73d8f8",
+                "sha256:8af5a8917b8af42295e86b64903156b4f110a30dca5f3b5aedea123fbd638bff",
+                "sha256:8ec8ef42c6cd5856a7613dcd1eaf21e5573b2185263d87d27c8edcae33b62a61",
+                "sha256:91e43805ccafa0a91831f9cd5443aa34528c0c3f2cc48c4cb3d9a7721053874b",
+                "sha256:9505dc359edb6a330efcd2be825fdb73ee3e628d9010597aa1aee5aa63442e97",
+                "sha256:985c7965f62f6f32bf432e2681173db41336a9c2611693247069288bcb0c7f8b",
+                "sha256:9a74041ba0bfa9bc9b9bb2cd3238a6ab3b7618e759b41bd15b5f6ad958d17605",
+                "sha256:9edbe6a5bf8b56a4a84533ba2b2f489d0046e755c29616ef8830f9e7d9cf5728",
+                "sha256:a15c1fe6d26e83fd2e5972425a772cca158eae58b05d4a25a4e474c221053e2d",
+                "sha256:a66bcdf19c1a523e41b8e9d53d0cedbfbac2e93c649a2e9502cb26c014d0980c",
+                "sha256:ae4070f741f8d809075ef697877fd350ecf0b7c5837ed68738607ee0a2c572cf",
+                "sha256:ae55d592b02c4349525b6ed8f74c692509e5adffa842e582c0f861751701a673",
+                "sha256:b578cbe580e3b41ad17b1c428f382c814b32a6ce90f2d8e39e2e635d49e498d1",
+                "sha256:b891a2f68e09c5ef989007fac11476ed33c5c9994449a4e2c3386529d703dc8b",
+                "sha256:baec8148d6b8bd5cee1ae138ba658c71f5b03e0d69d5907703e3e1df96db5e41",
+                "sha256:bb06098d019766ca16fc915ecaa455c1f1cd594204e7f840cd6258237b5079a8",
+                "sha256:bc791ec3fd0c4309a753f95bb6c749ef0d8ea3aea91f07ee1cf06b7b02118f2f",
+                "sha256:bd28b31730f0e982ace8663d108e01199098432a30a4c410d06fe08fdb9e93f4",
+                "sha256:be4d9c2770044a59715eb57c1144dedea7c5d5ae80c68fb9959515037cde2008",
+                "sha256:c0c72d34e7de5604df0fde3644cc079feee5e55464967d10b24b1de268deceb9",
+                "sha256:c0e842112fe3f1a4ffcf64b06dc4c61a88441c2f02f373367f7b4c1aa9be2ad5",
+                "sha256:c15070ebf11b8b7fd1bfff7217e9324963c82dbdf6182ff7050519e350e7ad9f",
+                "sha256:c2000c54c395d9e5e44c99dc7c20a64dc371f777faf8bae4919ad3e99ce5253e",
+                "sha256:c30187840d36d0ba2893bc3271a36a517a717f9fd383a98e2697ee890a37c273",
+                "sha256:cb7cd68814308aade9d0c93c5bd2ade9f9441666f8ba5aa9c2d4b389cb5e2a45",
+                "sha256:cd805513198304026bd379d1d516afbf6c3c13f4382134a2c526b8b854da1c2e",
+                "sha256:d0bf89afcbcf4d1bb2652f6580e5e55a840fdf87384f6063c4a4f0c95e378656",
+                "sha256:d9137a876020661972ca6eec0766d81aef8a5627df628b664b234b73396e727e",
+                "sha256:dbd95e300367aa0827496fe75a1766d198d34385a58f97683fe6e07f89ca3e3c",
+                "sha256:dced27917823df984fe0c80a5c4ad75cf58df0fbfae890bc08004cd3888922a2",
+                "sha256:de0b4caa1c8a21394e8ce971997614a17648f94e1cd0640fbd6b4d14cab13a72",
+                "sha256:debb633f3f7856f95ad957d9b9c781f8e2c6303ef21724ec94bea2ce2fcbd056",
+                "sha256:e372d7dfd154009142631de2d316adad3cc1c36c32a38b16a4751ba78da2a397",
+                "sha256:ecd26be9f112c4f96718290c10f4caea6cc798459a3a76636b817a0ed7874e42",
+                "sha256:edc0202099ea1d82844316604e17d2b175044f9bcb6b398aab781eba957224bd",
+                "sha256:f194cce575e59ffe442c10a360182a986535fd90b57f7debfaa5c845c409ecc3",
+                "sha256:f5fb672c396d826ca16a022ac04c9dce74e00a1c344f6ad1a0fdc1ba1f332213",
+                "sha256:f6a02a3c7950cafaadcd46a226ad9e12fc9744652cc69f9e5534f98b47f3bbcf",
+                "sha256:fe81b35c33772e56f4b6cf62cf4aedc1762ef7162a31e6ac7fe5e40d0149eb67"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==3.3.0"
+            "version": "==3.3.1"
         },
         "facebook-sdk": {
             "hashes": [
@@ -176,11 +176,11 @@
         },
         "google-api-python-client": {
             "hashes": [
-                "sha256:5b48dc23913b9a1b447991add03f27c335831559b5a870c522316eae671caf44",
-                "sha256:5d6cf80cc34598a85b73e7e689e6eb1ba34f342095aeab9ec408f94521382a7c"
+                "sha256:867061526aa6dc6c1481d118e913a8a38a02a01eed589413968397ebd77df71d",
+                "sha256:bbc66520e7fe9417b93fd113f2a0a1afa789d686de9009b6e94e48fdea50a60f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.103.0"
+            "version": "==2.104.0"
         },
         "google-auth": {
             "hashes": [
@@ -483,11 +483,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21",
-                "sha256:94a757d178c9be92ef5539b8840d48dc9cf1b2709c9d6b588232a055c524458b"
+                "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07",
+                "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.26.17"
+            "version": "==1.26.18"
         }
     },
     "develop": {

--- a/src/events.py
+++ b/src/events.py
@@ -346,14 +346,19 @@ class ActionNetworkEvent(Event):
         state = loc['region'] if 'region' in loc else ''
         zipcode = loc['postal_code'] if 'postal_code' in loc else ''
 
-        str_loc = f'{venue}, {addr}, {city} {state}, {zipcode}'
+        # Only include parts of the address that have non-whitespace content.
+        # Sometimes, hosts enter just the venue title such as 'Zoom' or
+        # 'City Hall'
+        str_loc = ", ".join([
+            part for part in [venue, addr, f'{city} {state}', zipcode] 
+            if part.strip()
+        ])
 
-        # I didn't find any flag that indicates the event is online.
+        # There is no flag that indicates the event is online.
         # Online events seemed to have the same lat/long, so we tried using that,
-        # but it wasn't always true, so some of our online event locations were just commas.
+        # but it wasn't always true, so some of our online event locations were empty.
         # Instead we'll try checking if they have no address.
-        if venue == '' and addr == '' and city == '' and state == '' and zipcode == '':
-            str_loc = 'Online'
+        if not str_loc: str_loc = 'Online'
 
         return str_loc
 

--- a/src/events.py
+++ b/src/events.py
@@ -52,7 +52,7 @@ class Event(ABC):
         return super().__repr__().replace(
             "object", f"{primary_id}|'{self.title}'"
         )
-    
+
     def print_diff(self, other):
         print(f"\nDifferences in Event: {self}")
         for field in self.event_fields().union(other.event_fields()):
@@ -137,7 +137,7 @@ class Event(ABC):
         :rtype: set
         """
         return set(dir(cls)) - set(dir(Event)) - cls.DERIVED_FIELD_NAMES
-    
+
     def event_info(self):
         """Get the names and values of all properties containing information
         about the event record itself.
@@ -145,9 +145,9 @@ class Event(ABC):
         :return: dictionary of event information
         :rtype: dict
         """
-        return { 
+        return {
             field: getattr(self, field)
-            for field in self.__class__.event_fields() 
+            for field in self.__class__.event_fields()
         }
 
     def translate_to(self, new_class):
@@ -177,7 +177,7 @@ class Event(ABC):
         # formatted strings, so use this as the default read behavior
         else:
             dt = datetime.fromisoformat(raw_time)
-        return dt  
+        return dt
 
     @classmethod
     def from_datetime(cls, dt):
@@ -247,7 +247,7 @@ class AirtableEvent(Event):
     @property
     def host_group(self):
         return self.lookup('fields', 'Host Group')
-    
+
     @host_group.setter
     def host_group(self, group_name):
         return self.set(group_name, 'fields', 'Host Group')
@@ -305,7 +305,7 @@ class ActionNetworkEvent(Event):
     @property
     def description(self):
         return self.lookup('description')
-    
+
     @property
     def host_group(self):
         return self.lookup('action_network:sponsor', 'title')
@@ -350,7 +350,7 @@ class ActionNetworkEvent(Event):
         # Sometimes, hosts enter just the venue title such as 'Zoom' or
         # 'City Hall'
         str_loc = ", ".join([
-            part for part in [venue, addr, f'{city} {state}', zipcode] 
+            part for part in [venue, addr, f'{city} {state}', zipcode]
             if part.strip()
         ])
 

--- a/src/events.py
+++ b/src/events.py
@@ -231,11 +231,18 @@ class AirtableEvent(Event):
 
     @property
     def description(self):
-        return self.lookup('fields', 'Description')
+        desc = self.lookup('fields', 'Description')
+        # When reading or comparing descriptions, ignore extra whitespace
+        # inserted by the Airtable platform
+        return desc.strip() if desc else desc
 
     @description.setter
     def description(self, description):
-        self.set(description, 'fields', 'Description')
+        # Airtable forums state that long text fields can store up to 100,000
+        # characters. Some of our ActionNetwork descriptions exceed this
+        # (primarily due to embedded images). For now, simply truncate to fit
+        airtable_desc = description[0:50000]
+        self.set(airtable_desc, 'fields', 'Description')
 
     @property
     def host_group(self):

--- a/src/events.py
+++ b/src/events.py
@@ -53,6 +53,14 @@ class Event(ABC):
         return super().__repr__().replace(
             "object", f"{primary_id}|'{self.title}'"
         )
+    
+    def print_diff(self, other):
+        print(f"\nDifferences in Event: {self}")
+        for field in self.event_fields().union(other.event_fields()):
+            self_value = self.event_info()[field]
+            other_value = other.event_info()[field]
+            if self_value != other_value:
+                print(f"Field {field}: {self_value} >> {other_value}")
 
     @property
     def primary_id(self):
@@ -364,7 +372,8 @@ class EventDiffer():
         self,
         events_from_source,
         events_at_destination,
-        destination_class=AirtableEvent
+        destination_class=AirtableEvent,
+        verbose=False
     ):
         """Create an EventDiffer.
 
@@ -376,7 +385,12 @@ class EventDiffer():
             with, in case there are no existing destination events to match
             against. defaults to AirtableEvent
         :type destination_class: class, optional
+        :param verbose: Whether to print detailed information about the
+            calculated changes. defaults to False
+        :type verbose: boolean, optional
         """
+        self.verbose = verbose
+
         self.events_from_source = events_from_source
         self.source_class = self._event_class(events_from_source)
 
@@ -460,6 +474,7 @@ class EventDiffer():
             event = source_event.translate_to(self.destination_class)
             event.primary_id = dest_event.primary_id
             if dest_event != event:
+                if self.verbose: dest_event.print_diff(event)
                 events_to_update.append(event)
         return events_to_update
 

--- a/src/sync.py
+++ b/src/sync.py
@@ -159,7 +159,7 @@ def handler(event, *_):
         events_from_source=actionnetwork_events,
         events_at_destination=airtable_events
     )
-    differ.diff_events()
+    differ.match_events()
 
     new_events = differ.events_to_add()
     changed_events = differ.events_to_update()

--- a/src/sync.py
+++ b/src/sync.py
@@ -142,6 +142,7 @@ def handler(event, *_):
     channel = event.get('channel') or SLACK_CHANNEL
     dryrun = event.get('dryrun') or False
     user = event.get('user')
+    verbose = event.get('verbose') or False
 
     actionnetwork_events = []
     for actionnetwork_group, actionnetwork_key in ACTION_NETWORK_GROUP_KEY_MAP.items():
@@ -151,13 +152,13 @@ def handler(event, *_):
         actionnetwork = ActionNetwork(actionnetwork_key)
         actionnetwork_events.extend(actionnetwork.events())
 
-
     airtable = Airtable(AIRTABLE_API_KEY, AIRTABLE_BASE_ID)
     airtable_events = airtable.events()
 
     differ = EventDiffer(
         events_from_source=actionnetwork_events,
-        events_at_destination=airtable_events
+        events_at_destination=airtable_events,
+        verbose=verbose
     )
     differ.match_events()
 
@@ -165,10 +166,16 @@ def handler(event, *_):
     changed_events = differ.events_to_update()
     removed_events = differ.events_to_delete()
 
-    print(f"All events retrieved from ActionNetwork: {actionnetwork_events}")
-    print(f"New events: {new_events}")
-    print(f"Changed events: {changed_events}")
-    print(f"Removed events: {removed_events}")
+    if verbose:
+        print(f"All events retrieved from ActionNetwork: {actionnetwork_events}")
+        print(f"New events: {new_events}")
+        print(f"Changed events: {changed_events}")
+        print(f"Removed events: {removed_events}")
+
+    print(f"{len(actionnetwork_events)} events retrieved from ActionNetwork")
+    print(f"{len(new_events)} new events: ")
+    print(f"{len(changed_events)} changed events")
+    print(f"{len(removed_events)} Removed events")
 
     if not dryrun:
         airtable.add_events(new_events)
@@ -180,10 +187,12 @@ if __name__ == '__main__':
                     prog = 'ActionNetwork',
                     description = 'Syncs events from ActionNetwork to Airtable')
     parser.add_argument('-s', '--sync', action='store_true')
+    parser.add_argument('-v', '--verbose', action='store_true')
     args = parser.parse_args()
 
     handler({
         'dryrun': not args.sync,
+        'verbose': args.verbose,
         'user': 'U7P1MU20P',
         'channel': 'GB1SLKKL7',
     })


### PR DESCRIPTION
Several bugfixes and improvements (one per commit):

Compare events by their contents, not updated time (https://github.com/BostonDSA/facebook-gcal-sync/commit/0df33df0b9a17c477ae18306783a77396eb813da)
- ensures we always and only update events when the contents actually change according to the event objects
- adds a method for comparing the contents of event objects

Add verbose option (https://github.com/BostonDSA/facebook-gcal-sync/commit/e113f216b8e30d32d5933ef47e260ee94735c310)
- adds script option to print info about all the events being synced, including which attributes differ for updated events

Correct time handling (https://github.com/BostonDSA/facebook-gcal-sync/commit/7bb1e6ba953e3f5b41e00bd916a623b2a1a0bcd4)
- upgrades python to 3.11
-- this is the latest version available on lambda
-- this version is able to read ISO time formats that have a trailing 'Z' indicating UTC
- clarifies and corrects the logic for translating the AN time to Eastern
- corresponding Airtable schema change: set airtable tz to Eastern

Fix description bugs (https://github.com/BostonDSA/facebook-gcal-sync/commit/97298cc091d499d1cd03b9d3cf736c2e3c553272)
- Airtable was adding newlines to our description text, causing the descriptions to not compare cleanly
- Airtable has a character limit which was exceeded when ActionNetwork events included base64 encoded images

Handle partial locations (https://github.com/BostonDSA/facebook-gcal-sync/commit/75751399407d48c191f8e59159ea55437b9ce2b7)
- Not all address parts are always used, which was leading to addresses like 'City Hall,,,'

Correct whitespace (https://github.com/BostonDSA/facebook-gcal-sync/commit/b87b2123529622083f1ee420dc26aa45f1fda190)

Add ARN to .env.example (https://github.com/BostonDSA/facebook-gcal-sync/commit/16a346be0f103cdae50ce27bd399d0565de59f31)
- needed for deploy process