### PR TITLE
Update handling of Airtable secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,12 +14,11 @@ SLACK_FOOTER_ICON=
 SLACK_FOOTER_URL=
 SLACK_TOPIC_ARN=
 
-# Action Network config
-# Key can be set for development to skip secrets manager
+# Action Network
 ACTION_NETWORK_GROUP_KEY_MAP=
-ACTION_NETWORK_SECRET_ID=actionnetwork
+ACTION_NETWORK_SECRET_ID=actionnetwork/development
 
 # Airtable
-AIRTABLE_API_KEY=
+AIRTABLE_PERSONAL_ACCESS_TOKEN=
 AIRTABLE_BASE_ID=
-AIRTABLE_SECRET_ID=
+AIRTABLE_SECRET_ID=airtable/development

--- a/src/airtable.py
+++ b/src/airtable.py
@@ -11,8 +11,8 @@ class Airtable(pyairtable.Table):
     is responsible for translating AirtableEvent objects into (or from) a
     format the API requires and calling the API functions.
     """
-    def __init__(self, api_key: str, base_id: str):
-        super().__init__(api_key, base_id, TABLE_NAME)
+    def __init__(self, personal_access_token: str, base_id: str):
+        super().__init__(personal_access_token, base_id, TABLE_NAME)
 
     def events(self) -> list[AirtableEvent]:
         return [AirtableEvent(event) for event in super().all()]

--- a/src/sync.py
+++ b/src/sync.py
@@ -26,13 +26,14 @@ if not ACTION_NETWORK_GROUP_KEY_MAP:
     raw_secret = SECRETSMANAGER.get_secret_value(SecretId=secret_id)
     ACTION_NETWORK_GROUP_KEY_MAP = json.loads(raw_secret['SecretString'])
 
+AIRTABLE_PERSONAL_ACCESS_TOKEN = os.environ.get('AIRTABLE_PERSONAL_ACCESS_TOKEN')
 AIRTABLE_BASE_ID = os.environ.get('AIRTABLE_BASE_ID')
-AIRTABLE_API_KEY = os.environ.get('AIRTABLE_API_KEY')
-if not AIRTABLE_API_KEY:
+if not AIRTABLE_PERSONAL_ACCESS_TOKEN and not AIRTABLE_BASE_ID:
     secret_id = os.environ['AIRTABLE_SECRET_ID']
     raw_secret = SECRETSMANAGER.get_secret_value(SecretId=secret_id)
     secret = json.loads(raw_secret['SecretString'])
-    AIRTABLE_API_KEY = secret['api_key']
+    AIRTABLE_PERSONAL_ACCESS_TOKEN = secret['personal_access_token']
+    AIRTABLE_BASE_ID = secret['base_id']
 
 def event_time(time):
     try:
@@ -152,7 +153,7 @@ def handler(event, *_):
         actionnetwork = ActionNetwork(actionnetwork_key)
         actionnetwork_events.extend(actionnetwork.events())
 
-    airtable = Airtable(AIRTABLE_API_KEY, AIRTABLE_BASE_ID)
+    airtable = Airtable(AIRTABLE_PERSONAL_ACCESS_TOKEN, AIRTABLE_BASE_ID)
     airtable_events = airtable.events()
 
     differ = EventDiffer(


### PR DESCRIPTION
API key -> Personal Access Token

Airtable deprecated API keys in favor of personal access tokens. Technically it is bad practice to use PATs as shared tokens or service keys, but since we don't have a 'service account' as per the Enterprise plan in airtable, this is our only option. Our bdsa.comms.systems@gmail.com user is a service account, and the scope of these keys is limited, so it should be ok. Docs: https://airtable.com/developers/web/guides/personal-access-tokens

The PATs have been set in Secrets Manager accordingly.