### PR TITLE
Mark cancelled events as removed

### DIFF
--- a/src/airtable.py
+++ b/src/airtable.py
@@ -22,6 +22,3 @@ class Airtable(pyairtable.Table):
 
     def update_events(self, events_to_update: list[AirtableEvent]):
         self.batch_update([event.raw for event in events_to_update])
-
-    def delete_events(self, events_to_delete: list[AirtableEvent]):
-        self.batch_delete([event.airtable_id for event in events_to_delete])

--- a/src/sync.py
+++ b/src/sync.py
@@ -164,8 +164,10 @@ def handler(event, *_):
     differ.match_events()
 
     new_events = differ.events_to_add()
-    changed_events = differ.events_to_update()
-    removed_events = differ.events_to_delete()
+
+    updated_events = differ.events_to_update()
+    changed_events = [e for e in updated_events if not e.removed]
+    removed_events = [e for e in updated_events if e.removed]
 
     if verbose:
         print(f"All events retrieved from ActionNetwork: {actionnetwork_events}")
@@ -180,8 +182,8 @@ def handler(event, *_):
 
     if not dryrun:
         airtable.add_events(new_events)
-        airtable.update_events(changed_events)
-        airtable.delete_events(removed_events)
+        # Cancelled events are marked removed in Airtable by updating them
+        airtable.update_events(changed_events + removed_events)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
Airtable does not provide an automation trigger based on a deleted event, and also does not provide an automation action to delete a calendar event. So, in order to remove an event from the calendar when it is cancelled in ActionNetwork, we need to:
- set a removed flag in actionnetwork
- use a no-code tool to delete in calendar

I went with make.com which was recommended on airtable forums:
![Screenshot 2023-10-24 at 10 49 30 PM](https://github.com/BostonDSA/facebook-gcal-sync/assets/6454888/386d0e6f-c4fe-4163-b28b-dc1be3de0c41)
I don't love introducing another separate tool into this ecosystem, but it seems to be the easiest way to get this working. Open to other ideas or approaches.

One alternative: @polecheck had previously discovered that ActionNetwork doesn't delete events, it just marks them "cancelled", and suggested that we might just want to mark cancelled events as such on the calendar rather than removing them. Would that be preferable to actual deletes?

Additionally, this PR removes the unused code paths related to actual deletion, since the sync script now is only responsible for setting a flag.